### PR TITLE
Fix missing API route for creating watchlists

### DIFF
--- a/backend/routes/watchlists.js
+++ b/backend/routes/watchlists.js
@@ -34,6 +34,22 @@ module.exports = (pool) => {
     res.status(500).json({ error: err.message });
   }
 });
+  // POST /api/watchlists
+  router.post('/', async (req, res) => {
+    const { name, user_id, type } = req.body;
+    if (!name || !user_id) {
+      return res.status(400).json({ error: 'Eksik parametre' });
+    }
+    try {
+      const result = await pool.query(
+        'INSERT INTO watchlists (name, user_id, type) VALUES ($1, $2, $3) RETURNING *',
+        [name, user_id, type || null]
+      );
+      res.status(201).json(result.rows[0]);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
 
 
 


### PR DESCRIPTION
## Summary
- add POST `/api/watchlists` to backend to allow creation of lists/portfolios

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840f6810a3c832ca65dab4eaa503982