### PR TITLE
Remove title from PortfolioDetail header

### DIFF
--- a/screens/asset/PortfolioDetailScreen.js
+++ b/screens/asset/PortfolioDetailScreen.js
@@ -50,6 +50,28 @@ const PortfolioDetailScreen = () => {
   const navigation = useNavigation();
   const { listId, listName } = route.params;
 
+  // Customize header: hide default title and use a stylish back button
+  useEffect(() => {
+    navigation.setOptions({
+      headerTitle: '',
+      headerBackTitleVisible: false,
+      headerTintColor: AppColors.primaryText,
+      headerBackImage: () => (
+        <Ionicons
+          name="arrow-back"
+          size={24}
+          color={AppColors.primaryText}
+          style={{ marginLeft: 15 }}
+        />
+      ),
+      headerStyle: {
+        backgroundColor: AppColors.background,
+        elevation: 0,
+        shadowOpacity: 0,
+      },
+    });
+  }, [navigation]);
+
   const [positions, setPositions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false); 


### PR DESCRIPTION
## Summary
- remove automatic title from `PortfolioDetail` screen
- add custom back button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840f9d26fdc832ca3dddd3640fece6f