### PR TITLE
Improve AddPosition behavior

### DIFF
--- a/App.js
+++ b/App.js
@@ -25,7 +25,11 @@ const App = () => {
         <Stack.Screen name="StockDetail" component={StockDetailScreen} options={{ title: 'Hisse Detayı' }} />
         <Stack.Screen name="WatchlistDetail" component={WatchlistDetailScreen} />
         <Stack.Screen name="PortfolioDetail" component={PortfolioDetailScreen} />
-        <Stack.Screen name="AddPosition" component={AddPositionScreen} />
+        <Stack.Screen
+          name="AddPosition"
+          component={AddPositionScreen}
+          options={{ title: '' }}
+        />
         <Stack.Screen name="AccountInfo" component={AccountInfoScreen} options={{ title: 'Hesap Bilgileri' }} />
         <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Şifre Değiştir' }} />
 

--- a/screens/asset/AddPositionScreen.js
+++ b/screens/asset/AddPositionScreen.js
@@ -1,5 +1,5 @@
 // screens/AddPositionScreen.js
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import {
   View,
   Text,
@@ -29,6 +29,8 @@ const AddPositionScreen = () => {
   const [stocks, setStocks] = useState([]);
   const [filteredStocks, setFilteredStocks] = useState([]);
   const [searchText, setSearchText] = useState('');
+  const [showStocks, setShowStocks] = useState(false);
+  const searchInputRef = useRef(null);
 
   useEffect(() => {
     const fetchStocks = async () => {
@@ -109,7 +111,12 @@ const AddPositionScreen = () => {
   const renderStockItem = ({ item }) => (
     <TouchableOpacity
       style={styles.stockItem}
-      onPress={() => setSymbol(item.symbol)}
+      onPress={() => {
+        setSymbol(item.symbol);
+        setSearchText(item.symbol);
+        setShowStocks(false);
+        searchInputRef.current?.blur();
+      }}
     >
       <Text style={styles.symbol}>{item.symbol}</Text>
       <Text>{item.companyName}</Text>
@@ -118,20 +125,24 @@ const AddPositionScreen = () => {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{isEdit ? 'Pozisyonu Düzenle' : 'Pozisyon Ekle'}</Text>
 
       <TextInput
         placeholder="Hisse ara"
         style={styles.input}
+        ref={searchInputRef}
         value={searchText}
         onChangeText={handleSearch}
+        onFocus={() => setShowStocks(true)}
+        onBlur={() => setShowStocks(false)}
       />
-      <FlatList
-        data={filteredStocks}
-        keyExtractor={(item) => item.symbol}
-        renderItem={renderStockItem}
-        style={{ maxHeight: 200, marginBottom: 12 }}
-      />
+      {showStocks && (
+        <FlatList
+          data={filteredStocks}
+          keyExtractor={(item) => item.symbol}
+          renderItem={renderStockItem}
+          style={{ maxHeight: 200, marginBottom: 12 }}
+        />
+      )}
 
       {symbol !== '' && (
         <>
@@ -180,8 +191,11 @@ const AddPositionScreen = () => {
 };
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20 },
-  title: { fontSize: 22, fontWeight: 'bold', marginBottom: 20 },
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#fff',
+  },
   input: {
     borderWidth: 1,
     borderColor: '#ccc',
@@ -195,7 +209,7 @@ const styles = StyleSheet.create({
     color: '#555',
   },
   button: {
-    backgroundColor: '#ffa500',
+    backgroundColor: '#007bff',
     padding: 14,
     borderRadius: 8,
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- keep navigation header for AddPosition so the back button remains
- fill search box with chosen symbol and hide the list after selection
- show stock list only while the search box is focused

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840fb2ac214832ca5aeab83ad61a92e