### PR TITLE
Add language selector with basic i18n

### DIFF
--- a/App.js
+++ b/App.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
 
+import { LocalizationProvider, useLocalization } from './services/LocalizationContext';
+
 import LoginScreen from './screens/auth/LoginScreen';
 import RegisterScreen from './screens/auth/RegisterScreen';
 import StockDetailScreen from './screens/market/StockDetailScreen';
@@ -15,7 +17,8 @@ import MainTabs from './screens/TabBar'; // <--- Tab yapısı buradan gelecek
 
 const Stack = createStackNavigator();
 
-const App = () => {
+const RootNavigator = () => {
+  const { t } = useLocalization();
   return (
     <NavigationContainer>
       <Stack.Navigator initialRouteName="Login">
@@ -26,12 +29,18 @@ const App = () => {
         <Stack.Screen name="WatchlistDetail" component={WatchlistDetailScreen} />
         <Stack.Screen name="PortfolioDetail" component={PortfolioDetailScreen} options={{ headerShown: false }} />
         <Stack.Screen name="AddPosition" component={AddPositionScreen} options={{ headerShown: false }} />
-        <Stack.Screen name="AccountInfo" component={AccountInfoScreen} options={{ title: 'Hesap Bilgileri' }} />
-        <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: 'Şifre Değiştir' }} />
+        <Stack.Screen name="AccountInfo" component={AccountInfoScreen} options={{ title: t('Account Information') }} />
+        <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: t('Change Password') }} />
 
       </Stack.Navigator>
     </NavigationContainer>
   );
 };
+
+const App = () => (
+  <LocalizationProvider>
+    <RootNavigator />
+  </LocalizationProvider>
+);
 
 export default App;

--- a/screens/TabBar.js
+++ b/screens/TabBar.js
@@ -8,11 +8,13 @@ import FAQScreen from '../screens/FAQScreen';
 import AssetsScreen from '../screens/asset/AssetsScreen'
 import PortfolioRiskScreen from '../screens/PortfolioRiskScreen';
 import PortfolioDetailScreen from '../screens/asset/PortfolioDetailScreen';
+import { useLocalization } from '../services/LocalizationContext';
 
 
 const Tab = createBottomTabNavigator();
 
 export default function MainTabs() {
+  const { t } = useLocalization();
   return (
     <Tab.Navigator
       initialRouteName="Home"
@@ -41,7 +43,7 @@ export default function MainTabs() {
         name="Home"
         component={HomeScreen}
         options={{
-          tabBarLabel: 'Ana Sayfa',
+          tabBarLabel: t('Home'),
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons 
               name="home-sharp" 
@@ -55,7 +57,7 @@ export default function MainTabs() {
         name="Market"
         component={MarketScreen}
         options={{
-          tabBarLabel: 'Piyasa',
+          tabBarLabel: t('Market'),
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons 
               name="stats-chart" 
@@ -69,7 +71,7 @@ export default function MainTabs() {
         name="Risk"
         component={PortfolioRiskScreen}
         options={{
-          tabBarLabel: 'Risk',
+          tabBarLabel: t('Risk'),
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons 
               name="shield-outline" 
@@ -83,7 +85,7 @@ export default function MainTabs() {
         name="Profile"
         component={AssetsScreen}
         options={{
-          tabBarLabel: 'Assests',
+          tabBarLabel: t('Assets'),
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons 
               name="person" 
@@ -97,7 +99,7 @@ export default function MainTabs() {
         name="FAQ"
         component={FAQScreen}
         options={{
-          tabBarLabel: 'SSS',
+          tabBarLabel: t('FAQ'),
           tabBarIcon: ({ color, size, focused }) => (
             <Ionicons 
               name="help-circle" 

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -16,6 +16,7 @@ import {
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Ionicons } from '@expo/vector-icons';
 import AnimatedLogoBanner from './AnimatedLogoBanner';
+import { useLocalization } from '../../services/LocalizationContext';
 
 const LOGO = require('../../assets/Ekran Resmi 2025.png');
 
@@ -25,6 +26,7 @@ export default function LoginScreen({ navigation, route }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+  const { t } = useLocalization();
 
   // Animasyonlar (login kartı için)
   const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -55,7 +57,7 @@ export default function LoginScreen({ navigation, route }) {
   const handleLogin = async () => {
     setErrorMessage('');
     if (!email || !password) {
-      setErrorMessage('Please fill in all fields');
+      setErrorMessage(t('Please fill in all fields.'));
       return;
     }
     setIsLoading(true);
@@ -75,10 +77,10 @@ export default function LoginScreen({ navigation, route }) {
           routes: [{ name: 'Main' }],
         });
       } else {
-        setErrorMessage(data.error || 'Login failed');
+        setErrorMessage(data.error || t('Login failed'));
       }
     } catch (error) {
-      setErrorMessage('Something went wrong');
+      setErrorMessage(t('Something went wrong'));
     } finally {
       setIsLoading(false);
     }
@@ -98,16 +100,16 @@ export default function LoginScreen({ navigation, route }) {
             { opacity: fadeAnim, transform: [{ translateY: slideAnim }] },
           ]}
         >
-          <Text style={styles.title}>Login</Text>
-          <Text style={styles.subtitle}>Welcome back! Please login.</Text>
+          <Text style={styles.title}>{t('Login')}</Text>
+          <Text style={styles.subtitle}>{t('Welcome back! Please login.')}</Text>
 
           <View style={styles.formContainer}>
             {/* E-Mail */}
             <View style={styles.inputWrapper}>
-              <Text style={styles.label}>EMAIL</Text>
+              <Text style={styles.label}>{t('Email')}</Text>
               <TextInput
                 style={styles.input}
-                placeholder="Email Address"
+                placeholder={t('Email Address')}
                 value={email}
                 onChangeText={setEmail}
                 keyboardType="email-address"
@@ -118,11 +120,11 @@ export default function LoginScreen({ navigation, route }) {
 
             {/* Password */}
             <View style={styles.inputWrapper}>
-              <Text style={styles.label}>PASSWORD</Text>
+              <Text style={styles.label}>{t('PASSWORD')}</Text>
               <View style={styles.passwordContainer}>
                 <TextInput
                   style={styles.passwordInput}
-                  placeholder="Password"
+                  placeholder={t('Password')}
                   secureTextEntry={!isPasswordVisible}
                   value={password}
                   onChangeText={setPassword}
@@ -145,7 +147,7 @@ export default function LoginScreen({ navigation, route }) {
 
             {/* Forgot Password */}
             <TouchableOpacity style={styles.forgotPassword}>
-              <Text style={styles.forgotPasswordText}>Forgot Password?</Text>
+              <Text style={styles.forgotPasswordText}>{t('Forgot Password?')}</Text>
             </TouchableOpacity>
 
             {/* Login Button */}
@@ -157,15 +159,15 @@ export default function LoginScreen({ navigation, route }) {
               {isLoading ? (
                 <ActivityIndicator color="#FFFFFF" />
               ) : (
-                <Text style={styles.loginButtonText}>Login</Text>
+                <Text style={styles.loginButtonText}>{t('Login')}</Text>
               )}
             </TouchableOpacity>
 
             {/* Register link */}
             <View style={styles.registerContainer}>
-              <Text style={styles.footerText}>Don't have an account? </Text>
+              <Text style={styles.footerText}>{t("Don't have an account? ")}</Text>
               <TouchableOpacity onPress={() => navigation.navigate('Register')}>
-                <Text style={styles.registerLink}>Signup!</Text>
+                <Text style={styles.registerLink}>{t('Signup')}</Text>
               </TouchableOpacity>
             </View>
           </View>

--- a/screens/auth/RegisterScreen.js
+++ b/screens/auth/RegisterScreen.js
@@ -16,6 +16,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import AnimatedLogoBanner from './AnimatedLogoBanner';
+import { useLocalization } from '../../services/LocalizationContext';
 
 const LOGO = require('../../assets/Ekran Resmi 2025.png');
 
@@ -25,6 +26,7 @@ export default function RegisterScreen({ navigation }) {
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const { t } = useLocalization();
 
   // Animation values
   const fadeAnim = useRef(new Animated.Value(0)).current;
@@ -48,18 +50,18 @@ export default function RegisterScreen({ navigation }) {
 
   const handleRegister = async () => {
     if (!username || !email || !password) {
-      Alert.alert('Error', 'Please fill in all fields');
+      Alert.alert(t('Error'), t('Please fill in all fields.'));
       return;
     }
 
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
-      Alert.alert('Error', 'Please enter a valid email address');
+      Alert.alert(t('Error'), t('Please enter a valid email address'));
       return;
     }
 
     if (password.length < 6) {
-      Alert.alert('Error', 'Password should be at least 6 characters');
+      Alert.alert(t('Error'), t('Password should be at least 6 characters'));
       return;
     }
 
@@ -76,7 +78,7 @@ export default function RegisterScreen({ navigation }) {
       const data = await response.json();
 
       if (response.ok) {
-        Alert.alert('Success', 'Registration successful!');
+        Alert.alert(t('Success'), t('Registration successful!'));
         // Animate out before navigating
         Animated.parallel([
           Animated.timing(fadeAnim, {
@@ -93,10 +95,10 @@ export default function RegisterScreen({ navigation }) {
           navigation.navigate('Login', { fromRegister: true });
         });
       } else {
-        Alert.alert('Error', data.error || 'Registration failed');
+        Alert.alert(t('Error'), data.error || t('Registration failed'));
       }
     } catch (error) {
-      Alert.alert('Error', 'Something went wrong');
+      Alert.alert(t('Error'), t('Something went wrong'));
     } finally {
       setIsLoading(false);
     }
@@ -129,14 +131,14 @@ export default function RegisterScreen({ navigation }) {
             { opacity: fadeAnim, transform: [{ translateY: slideAnim }] }
           ]}
         >
-          <Text style={styles.title}>Create Account</Text>
-          <Text style={styles.subtitle}>Sign up to get started</Text>
+          <Text style={styles.title}>{t('Create Account')}</Text>
+          <Text style={styles.subtitle}>{t('Sign up to get started')}</Text>
 
           <View style={styles.formContainer}>
             <View style={styles.inputWrapper}>
-              <Text style={styles.label}>NAME</Text>
+              <Text style={styles.label}>{t('NAME')}</Text>
               <TextInput
-                placeholder="Full Name"
+                placeholder={t('Full Name')}
                 value={username}
                 onChangeText={setUsername}
                 style={styles.input}
@@ -146,9 +148,9 @@ export default function RegisterScreen({ navigation }) {
             </View>
 
             <View style={styles.inputWrapper}>
-              <Text style={styles.label}>EMAIL</Text>
+              <Text style={styles.label}>{t('Email')}</Text>
               <TextInput
-                placeholder="Email Address"
+                placeholder={t('Email Address')}
                 value={email}
                 onChangeText={setEmail}
                 keyboardType="email-address"
@@ -159,10 +161,10 @@ export default function RegisterScreen({ navigation }) {
             </View>
 
             <View style={styles.inputWrapper}>
-              <Text style={styles.label}>PASSWORD</Text>
+              <Text style={styles.label}>{t('PASSWORD')}</Text>
               <View style={styles.passwordContainer}>
                 <TextInput
-                  placeholder="Password"
+                  placeholder={t('Password')}
                   value={password}
                   onChangeText={setPassword}
                   secureTextEntry={!isPasswordVisible}
@@ -191,12 +193,12 @@ export default function RegisterScreen({ navigation }) {
               {isLoading ? (
                 <ActivityIndicator color="#FFFFFF" />
               ) : (
-                <Text style={styles.registerButtonText}>Register</Text>
+                <Text style={styles.registerButtonText}>{t('Register')}</Text>
               )}
             </TouchableOpacity>
 
             <View style={styles.loginContainer}>
-              <Text style={styles.loginText}>Already have an account? </Text>
+              <Text style={styles.loginText}>{t('Already have an account? ')}</Text>
               <TouchableOpacity
                 onPress={() => {
                   Animated.parallel([
@@ -215,7 +217,7 @@ export default function RegisterScreen({ navigation }) {
                   });
                 }}
               >
-                <Text style={styles.loginLink}>Login</Text>
+                <Text style={styles.loginLink}>{t('Login')}</Text>
               </TouchableOpacity>
             </View>
           </View>

--- a/screens/home/HomeScreen.js
+++ b/screens/home/HomeScreen.js
@@ -17,6 +17,7 @@ import axios from 'axios';
 import { Ionicons, FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from '@react-navigation/native';
+import { useLocalization } from '../../services/LocalizationContext';
 
 const { width } = Dimensions.get('window');
 const indexInfo = {
@@ -26,6 +27,7 @@ const indexInfo = {
 
 const HomeScreen = () => {
   const navigation = useNavigation();
+  const { t } = useLocalization();
   const [watchlists, setWatchlists] = useState([]);
   const [modalVisible, setModalVisible] = useState(false);
   const [newListName, setNewListName] = useState('');
@@ -691,10 +693,10 @@ const HomeScreen = () => {
         <View style={styles.modalContainer}>
           <View style={styles.profileMenuContent}>
             <TouchableOpacity style={styles.profileMenuItem} onPress={() => { setProfileMenuVisible(false); navigation.navigate('AccountInfo'); }}>
-              <Text style={styles.profileMenuText}>Hesap Bilgileri</Text>
+              <Text style={styles.profileMenuText}>{t('Account Information')}</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.profileMenuItem} onPress={() => { setProfileMenuVisible(false); navigation.navigate('ChangePassword'); }}>
-              <Text style={styles.profileMenuText}>Şifre Değiştir</Text>
+              <Text style={styles.profileMenuText}>{t('Change Password')}</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.profileMenuItem} onPress={async () => {
               setProfileMenuVisible(false);
@@ -702,7 +704,7 @@ const HomeScreen = () => {
               await AsyncStorage.removeItem('userId');
               navigation.reset({ index: 0, routes: [{ name: 'Login' }] });
             }}>
-              <Text style={styles.profileMenuText}>Çıkış Yap</Text>
+              <Text style={styles.profileMenuText}>{t('Logout')}</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/screens/profile/AccountInfoScreen.js
+++ b/screens/profile/AccountInfoScreen.js
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
-import { SafeAreaView, Text, StyleSheet, View } from 'react-native';
+import { SafeAreaView, Text, StyleSheet, View, TouchableOpacity } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useLocalization } from '../../services/LocalizationContext';
 
 const AccountInfoScreen = () => {
   const [userId, setUserId] = useState('');
+  const { language, setLanguage, t } = useLocalization();
 
   useEffect(() => {
     const loadUserId = async () => {
@@ -15,10 +17,27 @@ const AccountInfoScreen = () => {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Hesap Bilgileri</Text>
+      <Text style={styles.title}>{t('Account Information')}</Text>
       <View style={styles.infoRow}>
-        <Text style={styles.label}>Kullanıcı ID:</Text>
+        <Text style={styles.label}>{t('User ID:')}</Text>
         <Text style={styles.value}>{userId}</Text>
+      </View>
+      <View style={styles.languageRow}>
+        <Text style={styles.label}>{t('Language')}</Text>
+        <View style={styles.langOptions}>
+          <TouchableOpacity
+            onPress={() => setLanguage('tr')}
+            style={[styles.langButton, language === 'tr' && styles.langButtonActive]}
+          >
+            <Text style={styles.langButtonText}>{t('Turkish')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => setLanguage('en')}
+            style={[styles.langButton, language === 'en' && styles.langButtonActive]}
+          >
+            <Text style={styles.langButtonText}>{t('English')}</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     </SafeAreaView>
   );
@@ -30,6 +49,19 @@ const styles = StyleSheet.create({
   infoRow: { flexDirection: 'row', marginBottom: 10 },
   label: { fontWeight: '600', marginRight: 10 },
   value: { color: '#374151' },
+  languageRow: { marginTop: 20 },
+  langOptions: { flexDirection: 'row', marginTop: 10 },
+  langButton: {
+    borderWidth: 1,
+    borderColor: '#d1d5db',
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    marginRight: 10,
+  },
+  langButtonActive: { backgroundColor: '#1e3a8a' },
+  langButtonText: { color: '#000' },
+});
 });
 
 export default AccountInfoScreen;

--- a/screens/profile/ChangePasswordScreen.js
+++ b/screens/profile/ChangePasswordScreen.js
@@ -2,14 +2,16 @@ import React, { useState } from 'react';
 import { SafeAreaView, Text, TextInput, StyleSheet, TouchableOpacity, View, Alert } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
+import { useLocalization } from '../../services/LocalizationContext';
 
 const ChangePasswordScreen = () => {
   const [currentPassword, setCurrentPassword] = useState('');
   const [newPassword, setNewPassword] = useState('');
+  const { t } = useLocalization();
 
   const handleChange = async () => {
     if (!currentPassword || !newPassword) {
-      Alert.alert('Hata', 'Lütfen tüm alanları doldurun.');
+      Alert.alert(t('Error'), t('Please fill in all fields.'));
       return;
     }
 
@@ -22,35 +24,35 @@ const ChangePasswordScreen = () => {
       );
 
       if (res.status === 200) {
-        Alert.alert('Başarılı', 'Şifreniz güncellendi.');
+        Alert.alert(t('Success'), t('Password updated.'));
         setCurrentPassword('');
         setNewPassword('');
       }
     } catch (err) {
-      const msg = err?.response?.data?.error || 'Şifre güncellenemedi.';
-      Alert.alert('Hata', msg);
+      const msg = err?.response?.data?.error || t('Could not update password.');
+      Alert.alert(t('Error'), msg);
     }
   };
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Şifre Değiştir</Text>
+      <Text style={styles.title}>{t('Change Password')}</Text>
       <TextInput
-        placeholder="Mevcut Şifre"
+        placeholder={t('Current Password')}
         secureTextEntry
         style={styles.input}
         value={currentPassword}
         onChangeText={setCurrentPassword}
       />
       <TextInput
-        placeholder="Yeni Şifre"
+        placeholder={t('New Password')}
         secureTextEntry
         style={styles.input}
         value={newPassword}
         onChangeText={setNewPassword}
       />
       <TouchableOpacity style={styles.button} onPress={handleChange}>
-        <Text style={styles.buttonText}>Güncelle</Text>
+        <Text style={styles.buttonText}>{t('Update')}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/services/LocalizationContext.js
+++ b/services/LocalizationContext.js
@@ -1,0 +1,126 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const translations = {
+  en: {
+    'Account Information': 'Account Information',
+    'User ID:': 'User ID:',
+    'Change Password': 'Change Password',
+    'Current Password': 'Current Password',
+    'New Password': 'New Password',
+    Update: 'Update',
+    Error: 'Error',
+    'Please fill in all fields.': 'Please fill in all fields.',
+    Success: 'Success',
+    'Password updated.': 'Password updated.',
+    'Could not update password.': 'Could not update password.',
+    'Login failed': 'Login failed',
+    'Something went wrong': 'Something went wrong',
+    Login: 'Login',
+    'Welcome back! Please login.': 'Welcome back! Please login.',
+    PASSWORD: 'PASSWORD',
+    Password: 'Password',
+    'Forgot Password?': 'Forgot Password?',
+    "Don't have an account? ": "Don't have an account? ",
+    Signup: 'Signup!',
+    Email: 'EMAIL',
+    'Email Address': 'Email Address',
+    NAME: 'NAME',
+    'Full Name': 'Full Name',
+    'Create Account': 'Create Account',
+    'Sign up to get started': 'Sign up to get started',
+    Register: 'Register',
+    'Already have an account? ': 'Already have an account? ',
+    'Please enter a valid email address': 'Please enter a valid email address',
+    'Password should be at least 6 characters': 'Password should be at least 6 characters',
+    'Registration successful!': 'Registration successful!',
+    'Registration failed': 'Registration failed',
+    Home: 'Home',
+    Market: 'Market',
+    Risk: 'Risk',
+    Assets: 'Assets',
+    FAQ: 'FAQ',
+    'Change Language': 'Change Language',
+    Language: 'Language',
+    Turkish: 'Turkish',
+    English: 'English',
+    'Logout': 'Logout',
+  },
+  tr: {
+    'Account Information': 'Hesap Bilgileri',
+    'User ID:': 'Kullan\u0131c\u0131 ID:',
+    'Change Password': '\u015eifre De\u011fi\u015ftir',
+    'Current Password': 'Mevcut \u015eifre',
+    'New Password': 'Yeni \u015eifre',
+    Update: 'G\u00fcncelle',
+    Error: 'Hata',
+    'Please fill in all fields.': 'L\u00fctfen t\u00fcm alanlar\u0131 doldurun.',
+    Success: 'Ba\u015far\u0131l\u0131',
+    'Password updated.': '\u015eifreniz g\u00fcncellendi.',
+    'Could not update password.': '\u015eifre g\u00fcncellenemedi.',
+    'Login failed': 'Giri\u015f ba\u015far\u0131s\u0131z',
+    'Something went wrong': 'Bir hata olu\u015ftu',
+    Login: 'Giri\u015f',
+    'Welcome back! Please login.': 'Tekrar ho\u015f geldiniz! L\u00fctfen giri\u015f yap\u0131n.',
+    PASSWORD: 'PAROLA',
+    Password: 'Parola',
+    'Forgot Password?': '\u015eifremi Unuttum?',
+    "Don't have an account? ": 'Hesab\u0131n\u0131z yok mu? ',
+    Signup: 'Kaydol!',
+    Email: 'E-POSTA',
+    'Email Address': 'E-posta Adresi',
+    NAME: '\u0130S\u0130M',
+    'Full Name': 'Ad Soyad',
+    'Create Account': 'Hesap Olu\u015ftur',
+    'Sign up to get started': 'Ba\u015flamak i\u00e7in kaydolun',
+    Register: 'Kaydol',
+    'Already have an account? ': 'Zaten bir hesab\u0131n\u0131z var m\u0131? ',
+    'Please enter a valid email address': 'Ge\u00e7erli bir e-posta girin',
+    'Password should be at least 6 characters': 'Parola en az 6 karakter olmal\u0131',
+    'Registration successful!': 'Kay\u0131t ba\u015far\u0131l\u0131!',
+    'Registration failed': 'Kay\u0131t ba\u015far\u0131s\u0131z',
+    Home: 'Ana Sayfa',
+    Market: 'Piyasa',
+    Risk: 'Risk',
+    Assets: 'Varl\u0131klar',
+    FAQ: 'SSS',
+    'Change Language': 'Dili De\u011fi\u015ftir',
+    Language: 'Dil',
+    Turkish: 'T\u00fcrk\u00e7e',
+    English: '\u0130ngilizce',
+    'Logout': '\u00c7\u0131k\u0131\u015f Yap',
+  },
+};
+
+const LocalizationContext = createContext({
+  language: 'en',
+  setLanguage: () => {},
+  t: (key) => key,
+});
+
+export const LocalizationProvider = ({ children }) => {
+  const [language, setLanguageState] = useState('en');
+
+  useEffect(() => {
+    const loadLang = async () => {
+      const stored = await AsyncStorage.getItem('language');
+      if (stored) setLanguageState(stored);
+    };
+    loadLang();
+  }, []);
+
+  const setLanguage = async (lang) => {
+    setLanguageState(lang);
+    await AsyncStorage.setItem('language', lang);
+  };
+
+  const t = (key) => translations[language][key] || key;
+
+  return (
+    <LocalizationContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LocalizationContext.Provider>
+  );
+};
+
+export const useLocalization = () => useContext(LocalizationContext);


### PR DESCRIPTION
## Summary
- implement `LocalizationContext` with Turkish and English translations
- wrap navigation in `LocalizationProvider`
- translate labels in login/register/profile screens and tab bar
- add language selector in account info screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841b9d9e978832c9299f045329d51b0