### PR TITLE
Add config for API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Finov
+
+This project uses environment variables to configure API endpoints. Create a `.env` file in the project root and define the URLs for the Node and machine learning backends.
+
+```bash
+API_BASE_URL=http://192.168.1.27:3000
+ML_BASE_URL=http://192.168.1.27:5050
+```
+
+These variables are loaded through `react-native-dotenv` and used in `services/config.js`.

--- a/screens/PortfolioRiskScreen.js
+++ b/screens/PortfolioRiskScreen.js
@@ -7,6 +7,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Ionicons } from '@expo/vector-icons';
 import { PieChart } from 'react-native-chart-kit';
 import { getStockHistory } from '../services/fmpApi';
+import { API_BASE_URL, ML_BASE_URL } from '../services/config';
 
 const AppColors = {
   background: '#F4F6F8',
@@ -123,12 +124,12 @@ const PortfolioRiskScreen = () => {
           return;
         }
         // Watchlists
-        const res = await fetch(`http://192.168.1.27:3000/api/watchlists/${userId}`);
+        const res = await fetch(`${API_BASE_URL}/api/watchlists/${userId}`);
         const watchlistData = await res.json();
         setWatchlists(watchlistData);
 
         // Öneriler
-        const recRes = await fetch("http://192.168.1.27:5050/recommend-low-risk");
+        const recRes = await fetch(`${ML_BASE_URL}/recommend-low-risk`);
         const recData = await recRes.json();
         setRecommendations(recData);
 
@@ -165,7 +166,7 @@ const PortfolioRiskScreen = () => {
         if (!indicators || beta === null) continue;
         const payload = { ...indicators, beta, symbol };
         riskDataPromises.push(
-          fetch("http://192.168.1.27:5050/predict-risk", {
+          fetch(`${ML_BASE_URL}/predict-risk`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(payload),

--- a/screens/asset/AddPositionScreen.js
+++ b/screens/asset/AddPositionScreen.js
@@ -18,6 +18,7 @@ import DateTimePicker from '@react-native-community/datetimepicker';
 import { useRoute, useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import { getSelectedStocks, getPriceOnDate } from '../../services/fmpApi';
+import { API_BASE_URL } from '../../services/config';
 
 const AddPositionScreen = () => {
   const route = useRoute();
@@ -64,7 +65,7 @@ const AddPositionScreen = () => {
     const fetchExisting = async () => {
       if (isEdit && listId && editSymbol) {
         try {
-          const res = await axios.get(`http://192.168.1.27:3000/api/watchlists/${listId}/stocks`);
+          const res = await axios.get(`${API_BASE_URL}/api/watchlists/${listId}/stocks`);
           const match = res.data.find((s) => s.symbol === editSymbol);
           if (match) {
             setSymbol(match.symbol);
@@ -99,7 +100,7 @@ const AddPositionScreen = () => {
       return;
     }
     try {
-      await axios.post(`http://192.168.1.27:3000/api/watchlists/${listId}/stocks`, {
+      await axios.post(`${API_BASE_URL}/api/watchlists/${listId}/stocks`, {
         symbol: symbol.toUpperCase(),
         quantity: parseFloat(quantity),
         price: parseFloat(price),

--- a/screens/asset/AssetsScreen.js
+++ b/screens/asset/AssetsScreen.js
@@ -19,8 +19,9 @@ import { getCurrentPrice } from '../../services/fmpApi';
 import { useNavigation } from '@react-navigation/native';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { useLocalization } from '../../services/LocalizationContext';
+import { API_BASE_URL } from '../../services/config';
 
-const API_BASE_URL = 'http://192.168.1.27:3000/api'; 
+const API_URL = `${API_BASE_URL}/api`;
 
 const COLORS = {
   primary: '#1A73E8',
@@ -48,7 +49,7 @@ const AssetsScreen = () => {
 
   const fetchPortfolioSummary = async (id) => {
     try {
-      const res = await axios.get(`${API_BASE_URL}/watchlists/${id}/stocks`);
+      const res = await axios.get(`${API_URL}/watchlists/${id}/stocks`);
       let cost = 0;
       let marketValue = 0;
       for (const pos of res.data) {
@@ -87,7 +88,7 @@ const AssetsScreen = () => {
         setLoading(false);
         return;
       }
-      const res = await axios.get(`${API_BASE_URL}/watchlists/${userId}?type=portfolio`);
+      const res = await axios.get(`${API_URL}/watchlists/${userId}?type=portfolio`);
 
       const portfoliosWithData = await Promise.all(
         res.data.map(async (portfolio) => ({
@@ -115,7 +116,7 @@ const AssetsScreen = () => {
         Alert.alert('Hata', 'Kullanıcı ID bulunamadı. Lütfen tekrar giriş yapın.');
         return;
       }
-      await axios.post(`${API_BASE_URL}/watchlists`, {
+      await axios.post(`${API_URL}/watchlists`, {
         name: newPortfolioName.trim(),
         user_id: userId, 
         type: 'portfolio',

--- a/screens/asset/PortfolioDetailScreen.js
+++ b/screens/asset/PortfolioDetailScreen.js
@@ -16,8 +16,9 @@ import { useRoute, useNavigation } from '@react-navigation/native';
 import { getStockDetails, getPriceOnDate, getCurrentPrice } from '../../services/fmpApi';
 import { Ionicons } from '@expo/vector-icons';
 import { PieChart } from 'react-native-chart-kit';
+import { API_BASE_URL } from '../../services/config';
 
-const API_URL = "http://192.168.1.27:3000";
+const API_URL = API_BASE_URL;
 
 const AppColors = {
   background: '#F4F6F8',

--- a/screens/auth/LoginScreen.js
+++ b/screens/auth/LoginScreen.js
@@ -17,6 +17,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Ionicons } from '@expo/vector-icons';
 import AnimatedLogoBanner from './AnimatedLogoBanner';
 import { useLocalization } from '../../services/LocalizationContext';
+import { API_BASE_URL } from '../../services/config';
 
 const LOGO = require('../../assets/Ekran Resmi 2025.png');
 
@@ -63,7 +64,7 @@ export default function LoginScreen({ navigation, route }) {
     setIsLoading(true);
     Keyboard.dismiss();
     try {
-      const response = await fetch('http://192.168.1.27:3000/login', {
+      const response = await fetch(`${API_BASE_URL}/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),

--- a/screens/auth/RegisterScreen.js
+++ b/screens/auth/RegisterScreen.js
@@ -17,6 +17,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import AnimatedLogoBanner from './AnimatedLogoBanner';
 import { useLocalization } from '../../services/LocalizationContext';
+import { API_BASE_URL } from '../../services/config';
 
 const LOGO = require('../../assets/Ekran Resmi 2025.png');
 
@@ -69,7 +70,7 @@ export default function RegisterScreen({ navigation }) {
     Keyboard.dismiss();
 
     try {
-      const response = await fetch('http://192.168.1.27:3000/register', {
+      const response = await fetch(`${API_BASE_URL}/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, password }),

--- a/screens/home/HomeScreen.js
+++ b/screens/home/HomeScreen.js
@@ -18,6 +18,7 @@ import { Ionicons, FontAwesome5, MaterialCommunityIcons } from "@expo/vector-ico
 import { LinearGradient } from "expo-linear-gradient";
 import { useNavigation } from '@react-navigation/native';
 import { useLocalization } from '../../services/LocalizationContext';
+import { API_BASE_URL } from '../../services/config';
 
 const { width } = Dimensions.get('window');
 const indexInfo = {
@@ -46,7 +47,7 @@ const HomeScreen = () => {
         console.warn('User ID bulunamadı. Kullanıcı giriş yapmamış olabilir.');
         return;
       }
-      const res = await axios.get(`http://192.168.1.27:3000/api/watchlists/${userId}`);
+      const res = await axios.get(`${API_BASE_URL}/api/watchlists/${userId}`);
       setWatchlists(res.data);
     } catch (err) {
       console.error('Liste çekme hatası', err);
@@ -58,7 +59,7 @@ const HomeScreen = () => {
   const createWatchlist = async () => {
     try {
       const userId = await AsyncStorage.getItem('userId');
-      const res = await axios.post('http://192.168.1.27:3000/api/watchlists', {
+      const res = await axios.post(`${API_BASE_URL}/api/watchlists`, {
         name: newListName,
         user_id: userId,
       });

--- a/screens/home/WatchlistDetailScreen.js
+++ b/screens/home/WatchlistDetailScreen.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, FlatList, StyleSheet, ActivityIndicator, Image, TouchableOpacity, Alert } from 'react-native';
 import axios from 'axios';
 import { Swipeable } from 'react-native-gesture-handler';
+import { API_BASE_URL } from '../../services/config';
 
 const WatchlistDetailScreen = ({ route }) => {
   const { listId } = route.params;
@@ -11,7 +12,7 @@ const WatchlistDetailScreen = ({ route }) => {
   // Fetch stocks for the given listId
   const fetchStocks = async () => {
     try {
-      const res = await axios.get(`http://192.168.1.27:3000/api/watchlists/${listId}/stocks`);
+      const res = await axios.get(`${API_BASE_URL}/api/watchlists/${listId}/stocks`);
       setStocks(res.data);
     } catch (err) {
       console.error('Liste içeriği çekilemedi', err);
@@ -35,7 +36,7 @@ const WatchlistDetailScreen = ({ route }) => {
   // Handle stock deletion
   const handleDelete = async (symbol) => {
     try {
-      await axios.delete(`http://192.168.1.27:3000/api/watchlists/${listId}/stocks/${symbol}`);
+      await axios.delete(`${API_BASE_URL}/api/watchlists/${listId}/stocks/${symbol}`);
       setStocks(stocks.filter(stock => stock.symbol !== symbol));  // Remove stock from local state
     } catch (err) {
       console.error("Hisse silinemedi", err);

--- a/screens/home/WatchlistScreen.js
+++ b/screens/home/WatchlistScreen.js
@@ -3,6 +3,7 @@ import { View, Text, FlatList, ActivityIndicator, StyleSheet, TouchableOpacity }
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import { useNavigation } from '@react-navigation/native';
+import { API_BASE_URL } from '../../services/config';
 
 const WatchlistScreen = () => {
   const [lists, setLists] = useState([]);
@@ -13,7 +14,7 @@ const WatchlistScreen = () => {
     const fetchLists = async () => {
       try {
         const userId = await AsyncStorage.getItem('userId');
-        const response = await axios.get(`http://192.168.1.27:3000/api/watchlists/${userId}`);
+        const response = await axios.get(`${API_BASE_URL}/api/watchlists/${userId}`);
         setLists(response.data);
       } catch (err) {
         console.error('Liste çekilemedi:', err);

--- a/screens/market/StockDetailScreen.js
+++ b/screens/market/StockDetailScreen.js
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { View, Text, ScrollView, ActivityIndicator, TouchableOpacity, Modal, Alert, Dimensions } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getStockDetails, getStockHistory } from '../../services/fmpApi';
+import { API_BASE_URL, ML_BASE_URL } from '../../services/config';
 import { LineChart } from 'react-native-chart-kit';
 import { Feather } from '@expo/vector-icons';
 import { styles } from "../../styles/StockDetailStyle";
@@ -85,7 +86,7 @@ const StockDetailScreen = ({ route, navigation }) => {
         const payload = { ...indicators, beta, symbol };
         console.log("Gönderilen veriler:", payload);
 
-        const response = await fetch("http://192.168.1.27:5050/predict-risk", {
+        const response = await fetch(`${ML_BASE_URL}/predict-risk`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(payload),
@@ -105,7 +106,7 @@ const StockDetailScreen = ({ route, navigation }) => {
       try {
         const userId = await AsyncStorage.getItem('userId');
         if (!userId) return;
-        const response = await fetch(`http://192.168.1.27:3000/api/watchlists/${userId}`);
+        const response = await fetch(`${API_BASE_URL}/api/watchlists/${userId}`);
         const data = await response.json();
         setWatchlists(data);
       } catch (err) {
@@ -126,7 +127,7 @@ const StockDetailScreen = ({ route, navigation }) => {
 
   const handleAddToWatchlist = async (listId) => {
     try {
-      const response = await fetch(`http://192.168.1.27:3000/api/watchlists/${listId}/stocks`, {
+      const response = await fetch(`${API_BASE_URL}/api/watchlists/${listId}/stocks`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ symbol }),
@@ -146,7 +147,7 @@ const StockDetailScreen = ({ route, navigation }) => {
   const handleAddWithFallback = async () => {
     const userId = await AsyncStorage.getItem('userId');
     if (watchlists.length === 0) {
-      const response = await fetch(`http://192.168.1.27:3000/api/watchlists`, {
+      const response = await fetch(`${API_BASE_URL}/api/watchlists`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: 'Favoriler', user_id: userId }),

--- a/screens/profile/ChangePasswordScreen.js
+++ b/screens/profile/ChangePasswordScreen.js
@@ -3,6 +3,7 @@ import { SafeAreaView, Text, TextInput, StyleSheet, TouchableOpacity, View, Aler
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import axios from 'axios';
 import { useLocalization } from '../../services/LocalizationContext';
+import { API_BASE_URL } from '../../services/config';
 
 const ChangePasswordScreen = () => {
   const [currentPassword, setCurrentPassword] = useState('');
@@ -18,7 +19,7 @@ const ChangePasswordScreen = () => {
     try {
       const token = await AsyncStorage.getItem('token');
       const res = await axios.post(
-        'http://192.168.1.27:3000/change-password',
+        `${API_BASE_URL}/change-password`,
         { currentPassword, newPassword },
         { headers: { Authorization: `Bearer ${token}` } }
       );

--- a/services/config.js
+++ b/services/config.js
@@ -1,0 +1,4 @@
+import { API_BASE_URL as ENV_API_BASE_URL, ML_BASE_URL as ENV_ML_BASE_URL } from '@env';
+
+export const API_BASE_URL = ENV_API_BASE_URL || 'http://192.168.1.27:3000';
+export const ML_BASE_URL = ENV_ML_BASE_URL || 'http://192.168.1.27:5050';


### PR DESCRIPTION
## Summary
- centralize backend URLs in `services/config.js`
- replace hardcoded backend addresses with config constants
- document environment variables in new README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684226345190832cab0abb87f32c5c0e