### PR TITLE
Fix risk score rounding and show price change

### DIFF
--- a/risk_api.py
+++ b/risk_api.py
@@ -30,7 +30,12 @@ def predict_risk():
             return jsonify({"error": f"Model bulunamadı: {symbol}"}), 404
 
         model = joblib.load(model_path)
-        score = model.predict(df)[0]
+        raw_score = model.predict(df)[0]
+        try:
+            score = float(raw_score)
+        except (ValueError, TypeError):
+            return jsonify({"error": f"Model output not numeric: {raw_score}"}), 500
+
         risk_percentage = round(score * 100)
 
         print("Tahmin skoru (%):", risk_percentage)

--- a/screens/market/MarketScreen.js
+++ b/screens/market/MarketScreen.js
@@ -59,8 +59,13 @@ const MarketScreen = () => {
 
   const renderItem = ({ item }) => {
     const price = Number(item.price).toFixed(2);
-    const priceColor = item.change > 0 ? styles.priceUp : item.change < 0 ? styles.priceDown : styles.priceNeutral;
-    const changeText = item.change > 0 ? `+${item.change}%` : `${item.change}%`;
+    const changePercent = Number(item.changesPercentage || 0);
+    const priceColor =
+      changePercent > 0 ? styles.priceUp : changePercent < 0 ? styles.priceDown : styles.priceNeutral;
+    const changeText =
+      changePercent > 0
+        ? `+${changePercent.toFixed(2)}%`
+        : `${changePercent.toFixed(2)}%`;
 
     return (
       <TouchableOpacity

--- a/services/fmpApi.js
+++ b/services/fmpApi.js
@@ -13,19 +13,20 @@ export const getSelectedStocks = async () => {
   // ];
 
   try {
-    const requests = symbols.map(symbol =>
-      fetch(`https://financialmodelingprep.com/api/v3/profile/${symbol}?apikey=${FMP_API_KEY}`)
-    );
+    const url = `https://financialmodelingprep.com/api/v3/quote/${symbols.join(',')}?apikey=${FMP_API_KEY}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    console.log('Quote data from API:', data);
 
-    const responses = await Promise.all(requests);
-    const jsonArrays = await Promise.all(responses.map(res => res.json()));
-
-    // 🔍 Buraya log ekle:
-    console.log("JSON arrays from API:", jsonArrays);
-
-    return jsonArrays
-      .map(arr => arr[0])
-      .filter(stock => stock && stock.symbol && stock.companyName);
+    return data
+      .filter(stock => stock && stock.symbol && stock.name)
+      .map(stock => ({
+        symbol: stock.symbol,
+        companyName: stock.name,
+        price: stock.price,
+        changes: stock.change,
+        changesPercentage: parseFloat(stock.changesPercentage),
+      }));
   } catch (error) {
     console.error('Error fetching selected stocks:', error);
     return [];


### PR DESCRIPTION
## Summary
- handle non-numeric ML outputs when rounding risk score
- fetch quotes for market list so change data is available
- display change percentage correctly on Market screen

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68423a50b0fc832caa35101c9565cddd