### PR TITLE
Add risk watchlist landing page

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,6 +12,7 @@ import PortfolioDetailScreen from './screens/asset/PortfolioDetailScreen';
 import AddPositionScreen from './screens/asset/AddPositionScreen';
 import AccountInfoScreen from './screens/profile/AccountInfoScreen';
 import ChangePasswordScreen from './screens/profile/ChangePasswordScreen';
+import PortfolioRiskScreen from './screens/PortfolioRiskScreen';
 
 import MainTabs from './screens/TabBar'; // <--- Tab yapısı buradan gelecek
 
@@ -31,6 +32,7 @@ const RootNavigator = () => {
         <Stack.Screen name="AddPosition" component={AddPositionScreen} options={{ headerShown: false }} />
         <Stack.Screen name="AccountInfo" component={AccountInfoScreen} options={{ title: t('Account Information') }} />
         <Stack.Screen name="ChangePassword" component={ChangePasswordScreen} options={{ title: t('Change Password') }} />
+        <Stack.Screen name="PortfolioRisk" component={PortfolioRiskScreen} options={{ headerShown: false }} />
 
       </Stack.Navigator>
     </NavigationContainer>

--- a/screens/PortfolioRiskScreen.js
+++ b/screens/PortfolioRiskScreen.js
@@ -8,7 +8,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { PieChart } from 'react-native-chart-kit';
 import { getStockHistory, getStockDetails } from '../services/fmpApi';
 import { API_BASE_URL, ML_BASE_URL } from '../services/config';
-import { useNavigation, useFocusEffect } from '@react-navigation/native';
+import { useNavigation, useFocusEffect, useRoute } from '@react-navigation/native';
 
 const AppColors = {
   background: '#F4F6F8',
@@ -120,6 +120,7 @@ const PortfolioRiskScreen = () => {
   const [featureModalVisible, setFeatureModalVisible] = useState(false);
 
   const navigation = useNavigation();
+  const route = useRoute();
 
 
   const fetchFeatureImportance = async (symbol, indicators) => {
@@ -169,8 +170,15 @@ const PortfolioRiskScreen = () => {
       setRecommendations([]);
     }
 
-    if (lists.length > 0) {
-      await handleListSelect(lists[0], true);
+    let initialList = null;
+    if (route.params?.listId) {
+      initialList = lists.find(l => l.id === route.params.listId || l._id === route.params.listId);
+    }
+    if (!initialList && lists.length > 0) {
+      initialList = lists[0];
+    }
+    if (initialList) {
+      await handleListSelect(initialList, true);
     } else {
       setLoading(false);
     }

--- a/screens/TabBar.js
+++ b/screens/TabBar.js
@@ -6,7 +6,7 @@ import HomeScreen from '../screens/home/HomeScreen';
 import MarketScreen from '../screens/market/MarketScreen';
 import FAQScreen from '../screens/FAQScreen';
 import AssetsScreen from '../screens/asset/AssetsScreen'
-import PortfolioRiskScreen from '../screens/PortfolioRiskScreen';
+import RiskHomeScreen from '../screens/risk/RiskHomeScreen';
 import PortfolioDetailScreen from '../screens/asset/PortfolioDetailScreen';
 import { useLocalization } from '../services/LocalizationContext';
 
@@ -69,7 +69,7 @@ export default function MainTabs() {
       />
       <Tab.Screen
         name="Risk"
-        component={PortfolioRiskScreen}
+        component={RiskHomeScreen}
         options={{
           tabBarLabel: t('Risk'),
           tabBarIcon: ({ color, size, focused }) => (

--- a/screens/risk/RiskHomeScreen.js
+++ b/screens/risk/RiskHomeScreen.js
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, ActivityIndicator, TouchableOpacity, StyleSheet } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Ionicons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { API_BASE_URL } from '../../services/config';
+
+const COLORS = {
+  background: '#F4F6F8',
+  card: '#FFFFFF',
+  primaryText: '#2C3E50',
+  secondaryText: '#7F8C8D',
+  action: '#3498DB',
+  separator: '#E0E6ED',
+};
+
+const RiskHomeScreen = () => {
+  const [lists, setLists] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigation = useNavigation();
+
+  useEffect(() => {
+    const fetchLists = async () => {
+      try {
+        const userId = await AsyncStorage.getItem('userId');
+        if (!userId) return;
+        const res = await fetch(`${API_BASE_URL}/api/watchlists/${userId}?type=risk`);
+        const data = await res.json();
+        setLists(data);
+      } catch (err) {
+        console.error('Risk listeleri çekilemedi', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchLists();
+  }, []);
+
+  const renderItem = ({ item }) => (
+    <TouchableOpacity
+      style={styles.item}
+      onPress={() => navigation.navigate('PortfolioRisk', { listId: item.id || item._id })}
+    >
+      <Text style={styles.itemText}>{item.name}</Text>
+      <Ionicons name="chevron-forward" size={20} color={COLORS.secondaryText} />
+    </TouchableOpacity>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.loader}>
+        <ActivityIndicator size="large" color={COLORS.action} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Risk Portföylerim</Text>
+      {lists.length === 0 ? (
+        <Text style={styles.emptyText}>Henüz oluşturulmuş risk portföyü bulunmuyor.</Text>
+      ) : (
+        <FlatList
+          data={lists}
+          keyExtractor={(item) => (item.id || item._id).toString()}
+          renderItem={renderItem}
+          contentContainerStyle={{ paddingVertical: 10 }}
+        />
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.background,
+    padding: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: COLORS.primaryText,
+    marginBottom: 16,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    backgroundColor: COLORS.card,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: COLORS.separator,
+    marginBottom: 12,
+  },
+  itemText: {
+    fontSize: 16,
+    color: COLORS.primaryText,
+  },
+  loader: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 16,
+    color: COLORS.secondaryText,
+    textAlign: 'center',
+    marginTop: 40,
+  },
+});
+
+export default RiskHomeScreen;


### PR DESCRIPTION
## Summary
- add `RiskHomeScreen` to display user's risk portfolios
- navigate to `PortfolioRiskScreen` when selecting a list
- wire new screen into tab bar and stack navigator
- allow `PortfolioRiskScreen` to accept a listId param

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844e7a31eb0832cb11bc153ec3a2c54