### PR TITLE
Fix high risk ratio

### DIFF
--- a/risk_api.py
+++ b/risk_api.py
@@ -138,7 +138,7 @@ def portfolio_analysis_endpoint():
     try:
         data = request.get_json(force=True)
         positions = data.get("positions", [])
-        threshold = data.get("high_risk_threshold", 0.6)
+        threshold = data.get("high_risk_threshold", 0.5)
         result = analyze_portfolio(positions, high_risk_threshold=threshold)
         return jsonify(result)
     except Exception as e:

--- a/screens/PortfolioRiskScreen.js
+++ b/screens/PortfolioRiskScreen.js
@@ -119,6 +119,9 @@ const PortfolioRiskScreen = () => {
   const [selectedFeatureImportance, setSelectedFeatureImportance] = useState(null);
   const [featureModalVisible, setFeatureModalVisible] = useState(false);
 
+  // Threshold for classifying a holding as high risk when sending data
+  const HIGH_RISK_THRESHOLD = 0.5; // 50%
+
   const navigation = useNavigation();
 
 
@@ -262,7 +265,7 @@ const PortfolioRiskScreen = () => {
         const analysisRes = await fetch(`${ML_BASE_URL}/portfolio-analysis`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ positions }),
+          body: JSON.stringify({ positions, high_risk_threshold: HIGH_RISK_THRESHOLD }),
         });
         const analysisJson = await analysisRes.json();
         setAnalysisSummary(analysisJson);


### PR DESCRIPTION
## Summary
- allow customizing high risk threshold from the app
- default threshold lowered to 50%

## Testing
- `pytest -q`
- `python -m py_compile risk_api.py portfolio_analysis.py portfolio_risk.py`

------
https://chatgpt.com/codex/tasks/task_e_6844e899446c832ca2ed2b4f8e92609e