### PR TITLE
Fix low-risk recommendation logic

### DIFF
--- a/risk_api.py
+++ b/risk_api.py
@@ -87,6 +87,7 @@ def predict_risk():
 @app.route("/recommend-low-risk", methods=["GET"])
 def recommend_low_risk():
     try:
+        all_scores = []
         recommendations = []
         for filename in os.listdir(MODEL_DIR):
             if filename.endswith("_risk_model.pkl"):
@@ -123,9 +124,14 @@ def recommend_low_risk():
                 model = joblib.load(model_path)
                 score = model.predict(df_model)[0]
                 risk = round(score * 100)
+                all_scores.append({"symbol": symbol, "risk_percentage": risk})
 
                 if risk < 30:
-                    recommendations.append({"symbol": symbol, "risk": risk})
+                    recommendations.append({"symbol": symbol, "risk_percentage": risk})
+
+        if not recommendations:
+            all_scores.sort(key=lambda x: x["risk_percentage"])
+            recommendations = all_scores[:3]
 
         return jsonify(recommendations)
 

--- a/tests/test_portfolio_risk.py
+++ b/tests/test_portfolio_risk.py
@@ -1,4 +1,8 @@
 import unittest
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from portfolio_risk import (
     calculate_portfolio_risk_advanced,
     value_at_risk,


### PR DESCRIPTION
## Summary
- expand `/recommend-low-risk` to always return data and include `risk_percentage`
- fix tests import path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68540a9d90d4832cbe6072b212f7afcc