### PR TITLE
Fix rounding type error in recommendation API

### DIFF
--- a/risk_api.py
+++ b/risk_api.py
@@ -128,7 +128,12 @@ def recommend_low_risk():
 
                 df_model = pd.DataFrame([features])
                 model = joblib.load(model_path)
-                score = model.predict(df_model)[0]
+                raw_score = model.predict(df_model)[0]
+                try:
+                    score = float(raw_score)
+                except (ValueError, TypeError):
+                    print(f"Invalid score for {symbol}: {raw_score}")
+                    continue
                 risk = round(score * 100)
                 all_scores.append({"symbol": symbol, "risk_percentage": risk})
 


### PR DESCRIPTION
## Summary
- fix `recommend_low_risk` to cast model output to float before rounding

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854385ad6a8832c9ee486d71ff9dd6b