### PR TITLE
Fix watchlist deletion and add stocks endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -106,6 +106,10 @@ app.get('/user/:id', async (req, res) => {
 const watchlistsRoute = require('./routes/watchlists')(pool); // ← dikkat: fonksiyon çağrısı
 app.use('/api/watchlists', watchlistsRoute);
 
+// 📈 Stocks routes - static list of symbols
+const stocksRoute = require('./routes/stocks');
+app.use('/api/stocks', stocksRoute);
+
 
 // 🚀 Başlat
 app.listen(port, () => {

--- a/backend/routes/stocks.js
+++ b/backend/routes/stocks.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const router = express.Router();
+
+// A static list of available stocks with basic symbol and name
+const stocks = [
+  { symbol: 'AAPL', name: 'Apple Inc.' },
+  { symbol: 'AMZN', name: 'Amazon.com Inc.' },
+  { symbol: 'BRK-B', name: 'Berkshire Hathaway B' },
+  { symbol: 'BRK-A', name: 'Berkshire Hathaway A' },
+  { symbol: 'META', name: 'Meta Platforms Inc.' },
+  { symbol: 'MSFT', name: 'Microsoft Corp.' },
+  { symbol: 'NVDA', name: 'NVIDIA Corp.' },
+  { symbol: 'TSLA', name: 'Tesla Inc.' },
+  { symbol: 'GM', name: 'General Motors Co.' },
+  { symbol: 'FLNC', name: 'Fluence Energy Inc.' },
+  { symbol: 'RC', name: 'Ready Capital Corp.' },
+  { symbol: 'APP', name: 'Applovin Corp.' },
+  { symbol: 'VTRS', name: 'Viatris Inc.' },
+  { symbol: 'GOOG', name: 'Alphabet Inc. Class C' },
+  { symbol: 'GOOGL', name: 'Alphabet Inc. Class A' },
+  { symbol: 'GTLL', name: 'Green Thumb Industries' },
+  { symbol: 'USO', name: 'United States Oil Fund' },
+  { symbol: 'BNO', name: 'United States Brent Oil Fund' },
+  { symbol: 'OIH', name: 'VanEck Oil Services ETF' },
+  { symbol: 'DBO', name: 'Invesco DB Oil Fund' },
+  { symbol: 'OIL', name: 'iPath Pure Beta Crude Oil ETN' },
+  { symbol: 'PXJ', name: 'Invesco Dynamic Oil & Gas Svcs ETF' },
+  { symbol: 'IEO', name: 'iShares U.S. Oil & Gas Exploration & Prod ETF' },
+  { symbol: 'UCO', name: 'ProShares Ultra Bloomberg Crude Oil' },
+  { symbol: 'XOP', name: 'SPDR S&P Oil & Gas Exploration & Prod ETF' },
+  { symbol: 'GUSH', name: 'Direxion Daily S&P Oil & Gas Bull 2X' },
+  { symbol: 'TBBK', name: 'The Bancorp Inc.' },
+  { symbol: 'SOUN', name: 'SoundHound AI Inc.' },
+  { symbol: 'NPWR', name: 'NET Power Inc.' },
+  { symbol: 'BBAI', name: 'BigBear.ai Holdings Inc.' },
+  { symbol: 'TKKYY', name: 'Tokuyama Corp.' },
+  { symbol: 'TKGBY', name: 'Turkiye Garanti Bankasi AS' }
+];
+
+router.get('/', (req, res) => {
+  res.json(stocks);
+});
+
+module.exports = router;

--- a/backend/routes/watchlists.js
+++ b/backend/routes/watchlists.js
@@ -117,6 +117,18 @@ router.post('/:listId/stocks', async (req, res) => {
       res.status(500).json({ error: err.message });
     }
   });
+
+  // DELETE /api/watchlists/:listId
+  router.delete('/:listId', async (req, res) => {
+    const { listId } = req.params;
+    try {
+      await pool.query('DELETE FROM watchlist_stocks WHERE watchlist_id = $1', [listId]);
+      await pool.query('DELETE FROM watchlists WHERE id = $1', [listId]);
+      res.sendStatus(204);
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
   
 
   return router;

--- a/screens/home/HomeScreen.js
+++ b/screens/home/HomeScreen.js
@@ -130,7 +130,13 @@ const HomeScreen = () => {
 
   const deleteWatchlist = async (listId) => {
 
-    Alert.alert("Yapım Aşamasında", "Bu özellik yakında eklenecektir.");
+    try {
+      await axios.delete(`${API_BASE_URL}/api/watchlists/${listId}`);
+      setWatchlists(current => current.filter(l => l.id !== listId));
+    } catch (err) {
+      console.error('Liste silinemedi', err);
+      Alert.alert('Hata', 'Liste silinirken bir sorun oluştu.');
+    }
 
   };
 


### PR DESCRIPTION
## Summary
- implement backend API to delete watchlists
- expose `/api/stocks` endpoint returning a list of symbols
- wire new endpoint in Express server
- hook up delete button in HomeScreen to call backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685498a97430832c9e5a8fd1fb8069c5