### PR TITLE
Fix watchlist filtering and bulk stock addition

### DIFF
--- a/screens/home/HomeScreen.js
+++ b/screens/home/HomeScreen.js
@@ -101,7 +101,7 @@ const HomeScreen = () => {
         console.warn('Kullanıcı ID bulunamadı.');
         return;
       }
-      const res = await axios.get(`${API_BASE_URL}/api/watchlists/${userId}`);
+      const res = await axios.get(`${API_BASE_URL}/api/watchlists/${userId}?type=watchlist`);
       setWatchlists(res.data);
     } catch (err) {
       console.error('Takip listesi çekme hatası', err);
@@ -118,6 +118,7 @@ const HomeScreen = () => {
       const res = await axios.post(`${API_BASE_URL}/api/watchlists`, {
         name: newListName.trim(),
         user_id: userId,
+        type: 'watchlist',
       });
       setWatchlists(prev => [...prev, res.data]);
       setNewListName('');


### PR DESCRIPTION
## Summary
- filter HomeScreen watchlists by type to exclude portfolios and risk lists
- tag new lists created from HomeScreen as `watchlist`
- allow backend watchlist route to add multiple symbols and ignore null types

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854a25d2e18832cbe290f204dd2dc51