### PR TITLE
Fix watchlist stock details

### DIFF
--- a/screens/home/WatchlistDetailScreen.js
+++ b/screens/home/WatchlistDetailScreen.js
@@ -13,10 +13,11 @@ import {
   Button,
   ActivityIndicator, 
 } from 'react-native';
-import axios from 'axios'; 
+import axios from 'axios';
 import { Swipeable } from 'react-native-gesture-handler';
 import { MaterialIcons } from '@expo/vector-icons';
-import { API_BASE_URL } from '../../services/config'; 
+import { API_BASE_URL } from '../../services/config';
+import { getQuotes } from '../../services/fmpApi';
 
 const WatchlistDetailScreen = ({ route }) => {
 
@@ -31,8 +32,14 @@ const WatchlistDetailScreen = ({ route }) => {
   const fetchWatchlistStocks = async () => {
     try {
       const res = await axios.get(`${API_BASE_URL}/api/watchlists/${listId}/stocks`);
-
-      setStocks(res.data);
+      const baseData = res.data || [];
+      const symbols = baseData.map(s => s.symbol);
+      const quotes = await getQuotes(symbols);
+      const enriched = baseData.map(item => {
+        const q = quotes.find(el => el.symbol === item.symbol) || {};
+        return { ...item, ...q };
+      });
+      setStocks(enriched);
     } catch (err) {
       console.error('Liste içeriği çekilemedi', err);
       Alert.alert("Hata", "İzleme listesi verileri alınamadı.");

--- a/services/fmpApi.js
+++ b/services/fmpApi.js
@@ -151,3 +151,23 @@ export const getCurrentPrice = async (symbol) => {
     return null;
   }
 };
+
+export const getQuotes = async (symbols = []) => {
+  if (!symbols || symbols.length === 0) return [];
+  try {
+    const url = `https://financialmodelingprep.com/api/v3/quote/${symbols.join(',')}?apikey=${FMP_API_KEY}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    if (!Array.isArray(data)) return [];
+    return data.map(q => ({
+      symbol: q.symbol,
+      name: q.name,
+      price: q.price,
+      change: q.change,
+      changePercentage: parseFloat(q.changesPercentage),
+    }));
+  } catch (error) {
+    console.error('Error fetching quotes:', error);
+    return [];
+  }
+};


### PR DESCRIPTION
## Summary
- add `getQuotes` helper in fmpApi to fetch data for multiple symbols
- use `getQuotes` inside WatchlistDetailScreen to enrich watchlist stocks

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854a4f654b0832c97965d0f80ad1027