### PR TITLE
Refresh risk screen after adding positions

### DIFF
--- a/screens/PortfolioRiskScreen.js
+++ b/screens/PortfolioRiskScreen.js
@@ -234,6 +234,23 @@ const PortfolioRiskScreen = () => {
     initialFetch();
   }, []);
 
+  // Refresh data when returning to this screen
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', async () => {
+      const lists = await fetchWatchlists();
+      const currentId = selectedList?.id || selectedList?._id;
+      if (currentId) {
+        const updated = lists.find(
+          (l) => l.id === currentId || l._id === currentId
+        );
+        if (updated) {
+          await handleListSelect(updated);
+        }
+      }
+    });
+    return unsubscribe;
+  }, [navigation, selectedList]);
+
   // Only fetch once when the screen mounts to avoid excessive network calls
   // Previously this ran on every focus, causing delays
 


### PR DESCRIPTION
## Summary
- refresh portfolio risk when returning to the screen so newly added stocks appear

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854a7a15e28832ca99ffcabbf719b6d