### PR TITLE
Fix recommendation fallback

### DIFF
--- a/screens/PortfolioRiskScreen.js
+++ b/screens/PortfolioRiskScreen.js
@@ -124,7 +124,11 @@ const PortfolioRiskScreen = () => {
 
   const filteredRecommendations = useMemo(() => {
     if (weightedRisk === null) return recommendations;
-    return recommendations.filter(r => r.risk_percentage < weightedRisk);
+    const filtered = recommendations.filter(
+      (r) => r.risk_percentage < weightedRisk
+    );
+    // Eğer filtrelenmiş sonuç yoksa, en düşük risklileri göster
+    return filtered.length > 0 ? filtered : recommendations;
   }, [recommendations, weightedRisk]);
 
   // Threshold for classifying a holding as high risk when sending data
@@ -653,11 +657,23 @@ const PortfolioRiskScreen = () => {
         </TouchableOpacity>
       </Modal>
 
-          {filteredRecommendations.length > 0 && (
+          {recommendations.length > 0 && (
             <View style={styles.sectionCard}>
               <Text style={styles.sectionTitle}>Düşük Riskli Hisse Önerileri</Text>
-              {filteredRecommendations.map((rec, index) => (
-                <View key={`${rec.symbol}-${index}`} style={[styles.recommendationItem, index === filteredRecommendations.length - 1 && styles.recommendationItemLast]}>
+              {filteredRecommendations.length === 0 && (
+                <Text style={styles.emptyStateMessage}>
+                  Portföy riskinizden düşük öneri bulunamadı. En düşük riskli hisseler görüntüleniyor.
+                </Text>
+              )}
+              {(filteredRecommendations.length > 0 ? filteredRecommendations : recommendations).map((rec, index) => (
+                <View
+                  key={`${rec.symbol}-${index}`}
+                  style={[
+                    styles.recommendationItem,
+                    (filteredRecommendations.length > 0 ? filteredRecommendations : recommendations).length - 1 === index &&
+                      styles.recommendationItemLast,
+                  ]}
+                >
                   <Ionicons
                     name={"bulb-outline"}
                     size={24}
@@ -672,12 +688,6 @@ const PortfolioRiskScreen = () => {
                   </View>
                 </View>
               ))}
-            </View>
-          )}
-          {filteredRecommendations.length === 0 && recommendations.length > 0 && (
-            <View style={styles.sectionCard}>
-              <Text style={styles.sectionTitle}>Düşük Riskli Hisse Önerileri</Text>
-              <Text style={styles.emptyStateMessage}>Portföy riskinizden düşük öneri bulunamadı.</Text>
             </View>
           )}
 


### PR DESCRIPTION
## Summary
- handle empty recommendation list by showing fallback from backend

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6854a6cf6b74832c8f4a245c8674dae9